### PR TITLE
Add option to request login when in debug mode (without LDAP)

### DIFF
--- a/zues/views.py
+++ b/zues/views.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 def generate_lid(lidnummer):
     lidnummer = int(lidnummer)
     if not hasattr(settings, 'JANEUS_SERVER'):
-        res = (b'', 'Onbekend lid'.encode('utf-8'))
+        res = (getattr(settings, 'DUMMY_MEMBER_EMAIL', b''), 'Onbekend lid'.encode('utf-8'))
     else:
         res = Janeus().attributes(lidnummer)
     if res is None:
@@ -225,7 +225,8 @@ def view_home(request):
 
                 secret_url = reverse('zues:login', kwargs={'key': key, 'lid': lid.lidnummer})
                 secret_url = request.build_absolute_uri(secret_url)
-                secret_url = re.sub(r'^http://', r'https://', secret_url)
+                if not settings.DEBUG:
+                    secret_url = re.sub(r'^http://', r'https://', secret_url)
 
                 if getattr(settings, 'EMAIL_HOST', '') == '':
                     return HttpResponseRedirect(secret_url)

--- a/zuessite/local_settings_example.py
+++ b/zuessite/local_settings_example.py
@@ -31,11 +31,14 @@ DATABASES = {
     }
 }
 
-# Step 5: set an LDAP server that stores the identity and access management data 
+# Step 5: set an LDAP server that stores the identity and access management data (production only)
 # JANEUS_SERVER = "ldap://127.0.0.1:389/"
 # JANEUS_DN = "cn=readall,ou=sysUsers,dc=jd,dc=nl"
 # JANEUS_PASS = ""
 # AUTHENTICATION_BACKENDS = ('janeus.backend.JaneusBackend', 'django.contrib.auth.backends.ModelBackend',)
+
+# define an email address for dummy members when bypassing LDAP (development only)
+# DUMMY_MEMBER_EMAIL = b'example@test.com'
 
 # Step 6: set Recaptcha-credentials.
 RECAPTCHA_PUBLIC_KEY = ''


### PR DESCRIPTION
Het idee is dat je tijdens het testen (in DEBUG mode) een login-url kan aanvragen door elk willekeurig lidnummer in te voeren. Voorheen kreeg je een foutmelding, omdat er een dummy user ("Onbekend lid") zonder e-mailadres aangemaakt wordt om de login-url naar te versturen.